### PR TITLE
~/work 以下に反映させるには末尾 / が必須

### DIFF
--- a/ja/04-ghq-get.md
+++ b/ja/04-ghq-get.md
@@ -63,7 +63,7 @@ root = ~/work
 Gitの設定の話になりますが、このとき、`includeIf`設定を併用すると、特定のgitconfigを特定のディレクトリ配下のリポジトリのみに適用することができます。`~/work`以下のリポジトリに対して仕事用のgitconfig(`~/work/.gitconfig`)を適用させる例が以下です。
 
 ```gitconfig
-[includeIf "gitdir:~/work"]
+[includeIf "gitdir:~/work/"]
 path = ~/work/.gitconfig
 ```
 


### PR DESCRIPTION
# Why
- `includeIf` の `gitdir` condition を使う場合に、特定ディレクトリ以下を実現するには末尾の `/` が必須
  - 正確にはglobのマッチなので `/**` が必要
  - https://git-scm.com/docs/git-config#_includes
  - > If the pattern ends with /, ** will be automatically added. For example, the pattern foo/ becomes foo/**. In other words, it matches "foo" and everything inside, recursively.
- 本文の
  - > ~/work`以下のリポジトリに対して
  - という説明に対して例の設定だと意図通りになっていなかったので修正

# What
- 例を修正して末尾 `/` を追加しました
